### PR TITLE
Fix asset paths for React and Vue wrappers

### DIFF
--- a/packages/react-library/dist/index.js
+++ b/packages/react-library/dist/index.js
@@ -1,2 +1,4 @@
+import { setAssetPath } from 'stencil-library/dist/components/index.js';
+setAssetPath(new URL('../stencil-library/dist/stencil-library/', import.meta.url).href);
 export * from './components/stencil-generated/components';
 //# sourceMappingURL=index.js.map

--- a/packages/react-library/dist/index.js.map
+++ b/packages/react-library/dist/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../lib/index.ts"],"names":[],"mappings":"AAAA,cAAc,2CAA2C,CAAC"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../lib/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,YAAY,EAAE,MAAM,0CAA0C,CAAC;AAExE,YAAY,CAAC,IAAI,GAAG,CAAC,0CAA0C,EAAE,MAAM,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,IAAI,CAAC,CAAC;AAExF,cAAc,2CAA2C,CAAC"}

--- a/packages/react-library/lib/index.ts
+++ b/packages/react-library/lib/index.ts
@@ -1,1 +1,5 @@
+import { setAssetPath } from 'stencil-library/dist/components/index.js';
+
+setAssetPath(new URL('../stencil-library/dist/stencil-library/', import.meta.url).href);
+
 export * from './components/stencil-generated/components';

--- a/packages/vue-library/dist/asset-path.d.ts
+++ b/packages/vue-library/dist/asset-path.d.ts
@@ -1,0 +1,1 @@
+export declare const ensureComponentAssetPath: () => void;

--- a/packages/vue-library/dist/asset-path.js
+++ b/packages/vue-library/dist/asset-path.js
@@ -1,0 +1,4 @@
+import { setAssetPath } from "stencil-library/dist/components/index.js";
+const assetsBaseUrl = new URL("../stencil-library/dist/stencil-library/", import.meta.url).href;
+export const ensureComponentAssetPath = () => setAssetPath(assetsBaseUrl);
+//# sourceMappingURL=asset-path.js.map

--- a/packages/vue-library/dist/asset-path.js.map
+++ b/packages/vue-library/dist/asset-path.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"asset-path.js","sourceRoot":"","sources":["../lib/asset-path.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,YAAY,EAAE,MAAM,0CAA0C,CAAA;AAEvE,MAAM,aAAa,GAAG,IAAI,GAAG,CAAC,0CAA0C,EAAE,MAAM,CAAC,IAAI,CAAC,GAAG,CAAC,CAAC,IAAI,CAAA;AAE/F,MAAM,CAAC,MAAM,wBAAwB,GAAG,GAAG,EAAE,CAAC,YAAY,CAAC,aAAa,CAAC,CAAA"}

--- a/packages/vue-library/dist/index.js
+++ b/packages/vue-library/dist/index.js
@@ -1,3 +1,5 @@
+import { ensureComponentAssetPath } from './asset-path';
+ensureComponentAssetPath();
 export * from './components';
 export * from './plugin';
 //# sourceMappingURL=index.js.map

--- a/packages/vue-library/dist/index.js.map
+++ b/packages/vue-library/dist/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../lib/index.ts"],"names":[],"mappings":"AAAA,cAAc,cAAc,CAAC;AAC7B,cAAc,UAAU,CAAC"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../lib/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,wBAAwB,EAAE,MAAM,cAAc,CAAC;AAExD,wBAAwB,EAAE,CAAC;AAE3B,cAAc,cAAc,CAAC;AAC7B,cAAc,UAAU,CAAC"}

--- a/packages/vue-library/dist/plugin.js
+++ b/packages/vue-library/dist/plugin.js
@@ -1,6 +1,8 @@
 import { defineCustomElements, } from "stencil-library/loader";
+import { ensureComponentAssetPath } from "./asset-path";
 export const ComponentLibrary = {
     async install() {
+        ensureComponentAssetPath();
         defineCustomElements();
     },
 };

--- a/packages/vue-library/dist/plugin.js.map
+++ b/packages/vue-library/dist/plugin.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"plugin.js","sourceRoot":"","sources":["../lib/plugin.ts"],"names":[],"mappings":"AAGA,OAAO,EACL,oBAAoB,GACrB,MAAM,wBAAwB,CAAA;AAE/B,MAAM,CAAC,MAAM,gBAAgB,GAAW;IACtC,KAAK,CAAC,OAAO;QACX,oBAAoB,EAAE,CAAA;IACxB,CAAC;CACF,CAAA"}
+{"version":3,"file":"plugin.js","sourceRoot":"","sources":["../lib/plugin.ts"],"names":[],"mappings":"AAGA,OAAO,EACL,oBAAoB,GACrB,MAAM,wBAAwB,CAAA;AAE/B,OAAO,EAAE,wBAAwB,EAAE,MAAM,cAAc,CAAA;AAEvD,MAAM,CAAC,MAAM,gBAAgB,GAAW;IACtC,KAAK,CAAC,OAAO;QACX,wBAAwB,EAAE,CAAC;QAC3B,oBAAoB,EAAE,CAAA;IACxB,CAAC;CACF,CAAA"}

--- a/packages/vue-library/lib/asset-path.ts
+++ b/packages/vue-library/lib/asset-path.ts
@@ -1,0 +1,5 @@
+import { setAssetPath } from "stencil-library/dist/components/index.js"
+
+const assetsBaseUrl = new URL("../stencil-library/dist/stencil-library/", import.meta.url).href
+
+export const ensureComponentAssetPath = () => setAssetPath(assetsBaseUrl)

--- a/packages/vue-library/lib/index.ts
+++ b/packages/vue-library/lib/index.ts
@@ -1,2 +1,6 @@
+import { ensureComponentAssetPath } from './asset-path';
+
+ensureComponentAssetPath();
+
 export * from './components';
 export * from './plugin';

--- a/packages/vue-library/lib/plugin.ts
+++ b/packages/vue-library/lib/plugin.ts
@@ -5,8 +5,11 @@ import {
   defineCustomElements,
 } from "stencil-library/loader"
 
+import { ensureComponentAssetPath } from "./asset-path"
+
 export const ComponentLibrary: Plugin = {
   async install() {
+    ensureComponentAssetPath();
     defineCustomElements()
   },
 }

--- a/packages/vue-library/tsconfig.json
+++ b/packages/vue-library/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "lib": ["dom", "es2020"],
-    "module": "es2015",
+    "module": "ESNext",
     "moduleResolution": "node",
     "target": "es2017",
     "skipLibCheck": true


### PR DESCRIPTION
## Summary
- set the Stencil asset base path in the React wrapper so icons resolve correctly
- add a reusable Vue helper to apply the same asset path and ensure the plugin calls it
- update the Vue TypeScript config to support import.meta usage needed for the asset path helper

## Testing
- npm run build (packages/react-library)
- npm run build (packages/vue-library)


------
https://chatgpt.com/codex/tasks/task_e_68d252ae0edc8329a6d1efb5ca4bd035