### PR TITLE
Fix Stencil icon assets for Vue app

### DIFF
--- a/packages/vue-app/vite.config.ts
+++ b/packages/vue-app/vite.config.ts
@@ -19,7 +19,13 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
+  },
+  optimizeDeps: {
+    exclude: ['vue-library', 'stencil-library'],
+  },
+  ssr: {
+    noExternal: ['vue-library', 'stencil-library'],
   },
 })

--- a/packages/vue-library/dist/plugin.js
+++ b/packages/vue-library/dist/plugin.js
@@ -1,6 +1,8 @@
-import { defineCustomElements, } from "stencil-library/loader";
+import { defineCustomElements, setAssetPath } from "stencil-library/loader";
+const ASSET_PATH = new URL("../stencil-library/dist/", import.meta.url).href;
 export const ComponentLibrary = {
     install() {
+        setAssetPath(ASSET_PATH);
         defineCustomElements();
     },
 };

--- a/packages/vue-library/dist/plugin.js.map
+++ b/packages/vue-library/dist/plugin.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"plugin.js","sourceRoot":"","sources":["../lib/plugin.ts"],"names":[],"mappings":"AAGA,OAAO,EACL,oBAAoB,GACrB,MAAM,wBAAwB,CAAA;AAE/B,MAAM,CAAC,MAAM,gBAAgB,GAAW;IACtC,OAAO;QACL,oBAAoB,EAAE,CAAA;IACxB,CAAC;CACF,CAAA"}
+{"version":3,"file":"plugin.js","sourceRoot":"","sources":["../lib/plugin.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,oBAAoB,EAAE,YAAY,KAAK;AACnD,MAAM,SAAS,GAAG,IAAI,GAAG,CAAC,0BAA0B,EAAE,WAAW,CAAC,IAAI,CAAC;AACpE,MAAM,CAAC,MAAM,gBAAgB,GAAW;IACtC,OAAO;QACL,YAAY,CAAC,SAAS,CAAC,CAAC;QACxB,oBAAoB,EAAE,CAAC;IAC1B,CAAC;CACF"}

--- a/packages/vue-library/lib/plugin.ts
+++ b/packages/vue-library/lib/plugin.ts
@@ -1,12 +1,13 @@
 import type { Plugin } from "vue"
 
 // @ts-ignore because Intellij does not understand imports within Lerna monorepos
-import {
-  defineCustomElements,
-} from "stencil-library/loader"
+import { defineCustomElements, setAssetPath } from "stencil-library/loader"
+
+const ASSET_PATH = new URL("../stencil-library/dist/", import.meta.url).href
 
 export const ComponentLibrary: Plugin = {
   install() {
+    setAssetPath(ASSET_PATH)
     defineCustomElements()
   },
 }


### PR DESCRIPTION
## Summary
- call `setAssetPath` in the Vue plugin before registering Stencil components so icon asset URLs resolve
- update the Vue app’s Vite configuration to exclude the local Stencil packages from prebundling, preserving their asset layout

## Testing
- `npm run build` (packages/stencil-library) *(fails: missing dependencies in offline environment)*
- `npm run build` (packages/vue-library) *(fails: missing type dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26fc1b8148329a2a9729bdac26127